### PR TITLE
fix: cdu troca

### DIFF
--- a/CdU.md
+++ b/CdU.md
@@ -21,7 +21,7 @@ Autor: vendedor
 Pré-condição: O vendedor deve estar autenticado no sistema
 
 1. Vendedor informa telefone do cliente
-2. Vendedor pesquisa por produto(s) a ser(em) incluido(s) (sublinhado)
+2. Vendedor pesquisa por produto(s) a ser(em) incluído(s) (sublinhado)
 3. Vendedor seleciona produtos
 4. Sistema registra hora e data da ordem de compra
 5. Sistema registra um código para a ordem de compra
@@ -112,7 +112,7 @@ Extensões:
 
 ## Registrar devolução 
 
-Ator: vendendor
+Ator: vendedor
 
 Pré-condição: O vendedor deve estar autenticado no sistema
 
@@ -125,7 +125,7 @@ Pré-condição: O vendedor deve estar autenticado no sistema
 
 ## Regitrar troca
 
-Ator: vendendor
+Ator: vendedor
 
 Pré-condição: O vendedor deve estar autenticado no sistema
 
@@ -140,7 +140,7 @@ Pré-condição: O vendedor deve estar autenticado no sistema
 
 ## Avaliar giro de estoque
 
-Ator: vendendor
+Ator: vendedor
 
 Pré-condição: O vendedor deve estar autenticado no sistema
 

--- a/HUs.md
+++ b/HUs.md
@@ -70,7 +70,7 @@ Critérios de Aceitação:
 - Gostaria de poder ter a opção de registrar trocas em todas as ordens de compra
 - Antes de registrar uma troca, devo ser capaz de ter filtros ao meu dispôr para encontrar mais facilmente a ordem de compra passível de troca de produtos, tais como nome e número do cliente e data da compra 
 - Gostaria de registrar a troca de um produto, pesquisando primeiro pelo produto a ser devolvido e depois pelo novo produto
-- O sistema não pode me permitir registrar uma troca cujo preço do novo produto seja menor que o devolvido
+- O sistema não pode me permitir registrar uma troca cujo preço do novo produto seja maior que o devolvido
 
 ## Avaliar giro de estoque
 


### PR DESCRIPTION
Corrigir pequeno erro, na história de usuário Troca de produtos, no último item substituir 'menor' por 'maior'.
'O sistema não pode me permitir registrar uma troca cujo preço do novo produto seja maior que o devolvido'
Pequenas correções em alguns casos de uso, havia 'vendendor' repetidas vezes.